### PR TITLE
Fix for latest rust in f25: undefined reference to `pthread_mutex_try…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,11 @@
 ACLOCAL_AMFLAGS = -I m4
 
-
 bin_PROGRAMS = hello_cargo
 
 hello_cargo_SOURCES = src/c/main.c
 hello_cargo_LDADD = libhello.la
+# Need to work out how to get this from rustc
+hello_cargo_LDFLAGS = -ldl -lpthread -lgcc_s -lc -lm -lrt -lutil
 
 lib_LTLIBRARIES = libhello.la
 
@@ -13,7 +14,11 @@ libhello_la_SOURCES = ""
 libhello_la_LIBADD = libcargo_example.a
 
 hello.o:
-	cd $(srcdir)/src/rust; cargo rustc -- --emit=obj -o $(abs_builddir)/hello.o
+	cd $(srcdir)/src/rust; cargo rustc -- --emit obj=$(abs_builddir)/hello.o
 
 libcargo_example.a:
-	cd $(srcdir)/src/rust; cargo rustc -- --emit=link -o $(abs_builddir)/$@
+	cd $(srcdir)/src/rust; cargo rustc -- --crate-type=staticlib --emit link -o $(abs_builddir)/$@
+
+clean-local:
+	cd $(srcdir)/src/rust; cargo clean
+

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 
 [lib]
-crate-type = ["staticlib"]
+# crate-type = ["staticlib"]
 
 [dependencies]


### PR DESCRIPTION
…lock'

Fix Description: The latest rustc / cargo does not work, as it no longer
links a set of libraries during build. This causes a large number of
undefined reference messages.

Add a LDFLAGS argument that provides the correct link arguments for linux.
Additionally, add a clean-local, allowing the make clean command to work.
